### PR TITLE
Replace prints in config with logging and update token env var

### DIFF
--- a/galactia/config.py
+++ b/galactia/config.py
@@ -9,10 +9,7 @@ from dotenv import load_dotenv
 
 # Load environment variables
 env_file = os.getenv("ENV_FILE", ".env")
-print(f"📦 Loading env from {env_file}")
 load_dotenv(dotenv_path=env_file)
-
-print(f"🚀 Starting Galactia in {os.getenv('ENV_MODE', 'undefined')} mode...")
 
 # Configure logging
 log_dir = "logs"
@@ -37,7 +34,14 @@ intents.members = True
 
 # External service tokens
 openai.api_key = os.getenv("OPENAI_API_KEY")
-DISCORD_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
+DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
 GUILD_ID = os.getenv("DISCORD_GUILD_ID")
 
 __all__ = ["intents", "DISCORD_TOKEN", "GUILD_ID"]
+
+if __name__ == "__main__":
+    logging.info("📦 Loading env from %s", env_file)
+    logging.info(
+        "🚀 Starting Galactia in %s mode...",
+        os.getenv("ENV_MODE", "undefined"),
+    )


### PR DESCRIPTION
## Summary
- use `logging.info` for config startup messages under a main guard
- read Discord token from `DISCORD_TOKEN` environment variable

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0b2f9bca08325a0368a7d274d212c