### PR TITLE
Limit message retrieval to requested amount

### DIFF
--- a/galactia/handlers/summary.py
+++ b/galactia/handlers/summary.py
@@ -55,8 +55,10 @@ async def fetch_valid_messages(
         )
         return match
 
-    raw_limit = 1000
-    history = channel.history(limit=raw_limit, after=start, before=end)
+    raw_limit = limit if limit is not None else 1000
+    history = channel.history(
+        limit=min(limit or raw_limit, raw_limit), after=start, before=end
+    )
     messages = []
     async for msg in history:
         if not msg.content:
@@ -74,7 +76,7 @@ async def fetch_valid_messages(
     logging.info(f"✅ Valid messages kept: {len(messages)}")
 
     messages.sort(key=lambda m: m.created_at, reverse=not sort_ascending)
-    return messages[:limit] if limit else messages
+    return messages
 
 
 async def generate_summary(messages, create_chat_completion, focus: Optional[str] = None):


### PR DESCRIPTION
## Summary
- Limit channel history retrieval to needed messages.
- Default to 1000 messages when no limit specified.

## Testing
- `python -m py_compile galactia/handlers/summary.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0c948b448832594a6be9a34f57924