### PR TITLE
Improve token budgeting using tiktoken

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 discord.py
 openai
+tiktoken
 python-dotenv
 python-dateutil
 pytz


### PR DESCRIPTION
## Summary
- use tiktoken tokenizer to count tokens instead of a length heuristic
- enforce token budget in `generate_summary` based on tokenizer counts
- add tiktoken dependency

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a0ea458a488325baacd7bcbb46739a