### PR TITLE
Centralize configuration with Pydantic settings

### DIFF
--- a/galactia/cogs/twitch.py
+++ b/galactia/cogs/twitch.py
@@ -11,6 +11,7 @@ import aiohttp
 import discord
 from discord import app_commands, Permissions
 from discord.ext import commands, tasks
+from galactia.settings import settings
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -145,10 +146,10 @@ class TwitchNotifier(commands.Cog):
 
     def __init__(self, bot: commands.Bot, session: aiohttp.ClientSession, exit_stack: AsyncExitStack):
         self.bot = bot
-        self.twitch_client_id = os.getenv("TWITCH_CLIENT_ID")
-        self.twitch_client_secret = os.getenv("TWITCH_CLIENT_SECRET")
-        self.check_interval = int(os.getenv("TWITCH_CHECK_INTERVAL", "60"))
-        self.fallback_channel_id = int(os.getenv("TWITCH_ANNOUNCE_CHANNEL_ID", "0"))
+        self.twitch_client_id = settings.twitch_client_id
+        self.twitch_client_secret = settings.twitch_client_secret
+        self.check_interval = settings.twitch_check_interval
+        self.fallback_channel_id = settings.twitch_announce_channel_id or 0
         self._oauth_token: Optional[str] = None
         self._oauth_expire_ts: float = 0
         self.session = session
@@ -760,7 +761,7 @@ async def setup(bot: commands.Bot):
 
     # 2) (Re)register the /twitch group explicitly
     try:
-        guild_id = os.getenv("DISCORD_GUILD_ID")
+        guild_id = settings.discord_guild_id
         if guild_id:
             guild = discord.Object(id=int(guild_id))
             # Remove any previous definition under the same name for that guild

--- a/galactia/config.py
+++ b/galactia/config.py
@@ -1,37 +1,7 @@
-import os
-import logging
-from datetime import datetime
-
 import discord
 import openai
-from dotenv import load_dotenv
 
-
-# Load environment variables
-env_file = os.getenv("ENV_FILE", ".env")
-load_dotenv(dotenv_path=env_file)
-
-# Configure logging
-log_dir = "logs"
-os.makedirs(log_dir, exist_ok=True)
-
-today = datetime.now().strftime("%Y-%m-%d")
-log_file_path = os.path.join(log_dir, f"Galactia_{today}.log")
-
-logging.basicConfig(
-    level=logging.INFO,
-    format="%(asctime)s [%(levelname)s] %(message)s",
-    handlers=[
-        logging.FileHandler(log_file_path, encoding="utf-8"),
-        logging.StreamHandler(),
-    ],
-)
-
-logging.info("📦 Loading env from %s", env_file)
-logging.info(
-    "🚀 Starting Galactia in %s mode...",
-    os.getenv("ENV_MODE", "undefined"),
-)
+from galactia.settings import settings
 
 # Discord intents
 intents = discord.Intents.default()
@@ -39,8 +9,8 @@ intents.message_content = True
 intents.members = True
 
 # External service tokens
-openai.api_key = os.getenv("OPENAI_API_KEY")
-DISCORD_TOKEN = os.getenv("DISCORD_TOKEN")
-GUILD_ID = os.getenv("DISCORD_GUILD_ID")
+openai.api_key = settings.openai_api_key
+DISCORD_TOKEN = settings.discord_token
+GUILD_ID = settings.discord_guild_id
 
 __all__ = ["intents", "DISCORD_TOKEN", "GUILD_ID"]

--- a/galactia/main.py
+++ b/galactia/main.py
@@ -1,4 +1,6 @@
 from galactia.bot import run
+from galactia.settings import configure_logging
 
 if __name__ == "__main__":
+    configure_logging()
     run()

--- a/galactia/settings.py
+++ b/galactia/settings.py
@@ -1,0 +1,47 @@
+import os
+import logging
+from datetime import datetime
+from pydantic import Field
+from pydantic_settings import BaseSettings
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+ENV_FILE = os.getenv("ENV_FILE", ".env")
+load_dotenv(dotenv_path=ENV_FILE)
+
+
+class Settings(BaseSettings):
+    """Application settings loaded from environment variables."""
+
+    discord_token: str = Field(env="DISCORD_TOKEN")
+    discord_guild_id: int | None = Field(default=None, env="DISCORD_GUILD_ID")
+    twitch_client_id: str = Field(env="TWITCH_CLIENT_ID")
+    twitch_client_secret: str = Field(env="TWITCH_CLIENT_SECRET")
+    twitch_check_interval: int = Field(default=60, env="TWITCH_CHECK_INTERVAL")
+    twitch_announce_channel_id: int | None = Field(default=None, env="TWITCH_ANNOUNCE_CHANNEL_ID")
+    openai_api_key: str = Field(env="OPENAI_API_KEY")
+    env_mode: str = Field(default="production", env="ENV_MODE")
+
+
+settings = Settings()
+
+
+def configure_logging() -> None:
+    """Configure application logging."""
+    log_dir = "logs"
+    os.makedirs(log_dir, exist_ok=True)
+
+    today = datetime.now().strftime("%Y-%m-%d")
+    log_file_path = os.path.join(log_dir, f"Galactia_{today}.log")
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[
+            logging.FileHandler(log_file_path, encoding="utf-8"),
+            logging.StreamHandler(),
+        ],
+    )
+
+    logging.info("📦 Loading env from %s", ENV_FILE)
+    logging.info("🚀 Starting Galactia in %s mode...", settings.env_mode)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 discord.py
 openai
 python-dotenv
+pydantic
+pydantic-settings
 python-dateutil
 pytz
 aiohttp


### PR DESCRIPTION
## Summary
- Add `galactia/settings.py` with a `Settings` model for env vars and a `configure_logging()` helper
- Swap direct `os.getenv` calls for `Settings` usage across config and Twitch cog
- Call centralized logging setup in `main.py` and declare new dependencies

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a0ea36d2b08325a5d658dfd903c67e