### PR TITLE
fix: refresh Twitch embed thumbnails

### DIFF
--- a/galactia/cogs/twitch.py
+++ b/galactia/cogs/twitch.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import shutil
+import time
 from contextlib import AsyncExitStack
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
@@ -720,6 +721,7 @@ class TwitchNotifier(commands.Cog):
         thumb = stream.get("thumbnail_url")
         if thumb:
             thumb = thumb.replace("{width}", "1280").replace("{height}", "720")
+            thumb = f"{thumb}?t={int(time.time())}"
             embed.set_image(url=thumb)
 
         # Footer with platform + published date (Europe/Paris)


### PR DESCRIPTION
## Summary
- bust Twitch embed cache by appending timestamp to live preview URLs
- import time for cache busting

## Testing
- `python3 -m py_compile galactia/cogs/twitch.py`
- `python3 -m pytest` *(fails: No module named pytest)*

------
https://chatgpt.com/codex/tasks/task_e_68aa48cd9b0083258aef9e2ed7f34a1e