### PR TITLE
Restrict Twitch, YouTube, and AI features to premium guilds

### DIFF
--- a/galactia/cogs/ai.py
+++ b/galactia/cogs/ai.py
@@ -22,6 +22,7 @@ from galactia.handlers.summary import (
     generate_summary,
     MAX_DISCORD,
 )
+from galactia.premium import is_premium_guild
 
 
 async def create_chat_completion(**params):
@@ -346,6 +347,9 @@ class AICog(commands.Cog):
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
         if message.author == self.bot.user:
+            return
+
+        if not message.guild or not is_premium_guild(message.guild.id):
             return
 
         if self.bot.user.mentioned_in(message):

--- a/galactia/cogs/twitch.py
+++ b/galactia/cogs/twitch.py
@@ -14,6 +14,7 @@ import discord
 from discord import app_commands, Permissions
 from discord.ext import commands, tasks
 from galactia.settings import settings
+from galactia.premium import premium_guild_only
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -190,6 +191,7 @@ class TwitchNotifier(commands.Cog):
     # ----- Admin commands -----
 
     @twitch_group.command(name="add", description="Follow a Twitch channel and announce its lives")
+    @premium_guild_only()
     @app_commands.describe(
         twitch_login="Twitch login (e.g. 'shroud')",
         channel="Discord channel for announcements",
@@ -249,6 +251,7 @@ class TwitchNotifier(commands.Cog):
         )
 
     @twitch_group.command(name="list", description="List followed Twitch channels")
+    @premium_guild_only()
     async def list_streams(self, interaction: discord.Interaction):
         async with self._streams_lock:
             data = list(self.streams)
@@ -269,6 +272,7 @@ class TwitchNotifier(commands.Cog):
         await interaction.response.send_message("\n".join(lines), ephemeral=True)
 
     @twitch_group.command(name="remove", description="Stop following a Twitch channel (all destinations)")
+    @premium_guild_only()
     @app_commands.describe(twitch_login="Twitch login to remove")
     async def twitch_remove(self, interaction: discord.Interaction, twitch_login: str):
         """Remove any follow entries for the given Twitch login."""
@@ -289,6 +293,7 @@ class TwitchNotifier(commands.Cog):
         )
 
     @twitch_group.command(name="test_online", description="Simulate a live (sends LIVE announcement)")
+    @premium_guild_only()
     @app_commands.describe(twitch_login="A previously followed Twitch login")
     async def twitch_test_online(self, interaction: discord.Interaction, twitch_login: str):
         """Simulate a LIVE stream announcement for testing."""
@@ -335,6 +340,7 @@ class TwitchNotifier(commands.Cog):
         await interaction.response.send_message("✅ Test LIVE sent.", ephemeral=True)
 
     @twitch_group.command(name="test_offline", description="Simulate end of live (edits to OFFLINE)")
+    @premium_guild_only()
     @app_commands.describe(twitch_login="A previously followed Twitch login")
     async def twitch_test_offline(self, interaction: discord.Interaction, twitch_login: str):
         """Simulate editing a previous LIVE message into an OFFLINE summary."""
@@ -355,6 +361,7 @@ class TwitchNotifier(commands.Cog):
         await interaction.response.send_message("✅ Test OFFLINE edited/sent.", ephemeral=True)
 
     @twitch_group.command(name="config", description="Show current Twitch notifier settings")
+    @premium_guild_only()
     async def twitch_show_config(self, interaction: discord.Interaction):
         channel = self.bot.get_channel(self.fallback_channel_id)
         channel_mention = channel.mention if channel else "None"
@@ -362,6 +369,7 @@ class TwitchNotifier(commands.Cog):
         await interaction.response.send_message(msg, ephemeral=True)
 
     @twitch_group.command(name="set_interval", description="Update Twitch poll interval in seconds")
+    @premium_guild_only()
     @app_commands.describe(seconds="Polling interval in seconds (minimum 10)")
     async def twitch_set_interval(self, interaction: discord.Interaction, seconds: int):
         if seconds < 10:
@@ -376,6 +384,7 @@ class TwitchNotifier(commands.Cog):
         )
 
     @twitch_group.command(name="set_channel", description="Set default announce channel")
+    @premium_guild_only()
     @app_commands.describe(channel="Channel where live notifications will be sent")
     async def twitch_set_channel(
         self, interaction: discord.Interaction, channel: discord.TextChannel

--- a/galactia/cogs/youtube.py
+++ b/galactia/cogs/youtube.py
@@ -13,6 +13,7 @@ import aiohttp
 import discord
 from discord import app_commands, Permissions
 from discord.ext import commands, tasks
+from galactia.premium import premium_guild_only
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
@@ -160,6 +161,7 @@ class YouTubeNotifier(commands.Cog):
 
     # -------- add --------
     @youtube_group.command(name="add", description="Follow a YouTube channel and announce its new videos.")
+    @premium_guild_only()
     @app_commands.describe(
         youtube_channel="YouTube channel URL or handle (e.g. https://youtube.com/@LimitMaximum or @LimitMaximum)",
         discord_channel="Discord channel for announcements",
@@ -223,6 +225,7 @@ class YouTubeNotifier(commands.Cog):
 
     # -------- list --------
     @youtube_group.command(name="list", description="List followed YouTube channels.")
+    @premium_guild_only()
     async def youtube_list(self, interaction: discord.Interaction):
         data = _sanitize_rows(_load_rows())
         if not data:
@@ -242,6 +245,7 @@ class YouTubeNotifier(commands.Cog):
 
     # -------- remove --------
     @youtube_group.command(name="remove", description="Stop following a YouTube channel (all destinations).")
+    @premium_guild_only()
     @app_commands.describe(youtube_channel="The channel URL or handle previously followed")
     async def youtube_remove(self, interaction: discord.Interaction, youtube_channel: str):
         await interaction.response.defer(ephemeral=True, thinking=True)
@@ -263,6 +267,7 @@ class YouTubeNotifier(commands.Cog):
 
     # -------- test_new --------
     @youtube_group.command(name="test_new", description="Simulate a new video announcement for a followed channel.")
+    @premium_guild_only()
     @app_commands.describe(youtube_channel="A followed channel URL/handle")
     async def youtube_test_new(self, interaction: discord.Interaction, youtube_channel: str):
         await interaction.response.defer(ephemeral=True, thinking=True)
@@ -296,6 +301,7 @@ class YouTubeNotifier(commands.Cog):
         name="test_update",
         description="Simulate an embed update for the last announcement (title/description change)."
     )
+    @premium_guild_only()
     @app_commands.describe(youtube_channel="A followed channel URL/handle")
     async def youtube_test_update(self, interaction: discord.Interaction, youtube_channel: str):
         await interaction.response.defer(ephemeral=True, thinking=True)

--- a/galactia/premium.py
+++ b/galactia/premium.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import discord
+from discord import app_commands
+
+from galactia.settings import settings
+
+DEFAULT_PREMIUM_GUILDS = {1372478988882022502, 881871369149759502}
+
+
+def is_premium_guild(guild_id: int | None) -> bool:
+    if guild_id is None:
+        return False
+    try:
+        gid = int(guild_id)
+    except (TypeError, ValueError):
+        return False
+    return gid in DEFAULT_PREMIUM_GUILDS or gid in settings.premium_guild_ids
+
+
+def premium_guild_only():
+    async def predicate(interaction: discord.Interaction) -> bool:
+        if is_premium_guild(interaction.guild_id):
+            return True
+        raise app_commands.CheckFailure("This feature requires the premium plan.")
+
+    return app_commands.check(predicate)

--- a/galactia/settings.py
+++ b/galactia/settings.py
@@ -1,7 +1,9 @@
 import os
 import logging
 from datetime import datetime
-from pydantic import Field
+from typing import List
+
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings
 from dotenv import load_dotenv
 
@@ -21,6 +23,14 @@ class Settings(BaseSettings):
     twitch_announce_channel_id: int | None = Field(default=None, env="TWITCH_ANNOUNCE_CHANNEL_ID")
     openai_api_key: str = Field(env="OPENAI_API_KEY")
     env_mode: str = Field(default="production", env="ENV_MODE")
+    premium_guild_ids: List[int] = Field(default_factory=list, env="PREMIUM_GUILD_IDS")
+
+    @field_validator("premium_guild_ids", mode="before")
+    @classmethod
+    def parse_premium_ids(cls, v):
+        if isinstance(v, str):
+            return [int(x.strip()) for x in v.split(",") if x.strip()]
+        return v or []
 
 
 settings = Settings()


### PR DESCRIPTION
## Summary
- add premium guild configuration with default allowlist
- gate Twitch and YouTube slash commands behind premium plan
- ignore AI features in messages from non-premium guilds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aac252c1148325826bac3cd335a4ba