### PR TITLE
Replace PremiumMembership with guild-scoped premium model

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -25,14 +25,14 @@ class Feature(Base):
     name: Mapped[str] = mapped_column(String(100))
     description: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-class PremiumMembership(Base):
-    __tablename__ = "premium_memberships"
+class GuildPremium(Base):
+    __tablename__ = "guild_premium"
     id: Mapped[int] = mapped_column(primary_key=True)
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), index=True)
-    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), index=True)
+    guild_id: Mapped[int] = mapped_column(ForeignKey("guilds.id"), unique=True, index=True)
     tier: Mapped[str] = mapped_column(String(32), default="premium")  # extensible
     expires_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
-    __table_args__ = (UniqueConstraint("user_id", "guild_id", name="uq_premium_user_guild"), )
+    granted_by: Mapped[int | None] = mapped_column(ForeignKey("users.id"), nullable=True)
+    __table_args__ = (UniqueConstraint("guild_id", name="uq_guild_premium"), )
 
 class GuildFeatureFlag(Base):
     __tablename__ = "guild_feature_flags"

--- a/migrations/versions/9d9a3bf77c3b_guild_premium_table.py
+++ b/migrations/versions/9d9a3bf77c3b_guild_premium_table.py
@@ -1,0 +1,81 @@
+"""guild premium table
+
+Revision ID: 9d9a3bf77c3b
+Revises: 64cf63a0a835
+Create Date: 2025-02-14 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '9d9a3bf77c3b'
+down_revision: Union[str, Sequence[str], None] = '64cf63a0a835'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.create_table(
+        'guild_premium',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('guild_id', sa.Integer(), nullable=False),
+        sa.Column('tier', sa.String(length=32), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.Column('granted_by', sa.Integer(), nullable=True),
+        sa.ForeignKeyConstraint(['guild_id'], ['guilds.id'], ),
+        sa.ForeignKeyConstraint(['granted_by'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('guild_id', name='uq_guild_premium')
+    )
+    op.create_index(op.f('ix_guild_premium_guild_id'), 'guild_premium', ['guild_id'], unique=True)
+
+    # migrate existing premium memberships to guild_premium
+    op.execute(
+        """
+        INSERT INTO guild_premium (guild_id, tier, expires_at, granted_by)
+        SELECT guild_id,
+               MAX(tier) AS tier,
+               MAX(expires_at) AS expires_at,
+               MAX(user_id) AS granted_by
+        FROM premium_memberships
+        GROUP BY guild_id
+        """
+    )
+
+    op.drop_index(op.f('ix_premium_memberships_user_id'), table_name='premium_memberships')
+    op.drop_index(op.f('ix_premium_memberships_guild_id'), table_name='premium_memberships')
+    op.drop_table('premium_memberships')
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.create_table(
+        'premium_memberships',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('guild_id', sa.Integer(), nullable=False),
+        sa.Column('tier', sa.String(length=32), nullable=False),
+        sa.Column('expires_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['guild_id'], ['guilds.id'], ),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'guild_id', name='uq_premium_user_guild')
+    )
+    op.create_index(op.f('ix_premium_memberships_guild_id'), 'premium_memberships', ['guild_id'], unique=False)
+    op.create_index(op.f('ix_premium_memberships_user_id'), 'premium_memberships', ['user_id'], unique=False)
+
+    op.execute(
+        """
+        INSERT INTO premium_memberships (user_id, guild_id, tier, expires_at)
+        SELECT COALESCE(granted_by, 0) AS user_id, guild_id, tier, expires_at
+        FROM guild_premium
+        """
+    )
+
+    op.drop_index(op.f('ix_guild_premium_guild_id'), table_name='guild_premium')
+    op.drop_table('guild_premium')

--- a/panel/deps.py
+++ b/panel/deps.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from fastapi import HTTPException, Request
 from sqlalchemy.orm import Session
 from sqlalchemy import select, and_
-from core.models import User, Guild, GuildMember, PremiumMembership
+from core.models import User, Guild, GuildMember, GuildPremium
 
 def require_auth_request(request: Request) -> dict:
     user = request.session.get("user")
@@ -37,10 +37,9 @@ def require_guild_admin(request: Request, guild_id: int, db: Session) -> Guild:
         raise HTTPException(403, "Guild admin only")
     return g
 
-def has_premium(user_db_id: int, guild_db_id: int, db: Session) -> bool:
-    pm = db.execute(select(PremiumMembership).where(and_(
-        PremiumMembership.user_id == user_db_id,
-        PremiumMembership.guild_id == guild_db_id,
-        (PremiumMembership.expires_at.is_(None)) | (PremiumMembership.expires_at > datetime.utcnow())
+def has_premium(guild_db_id: int, db: Session) -> bool:
+    pm = db.execute(select(GuildPremium).where(and_(
+        GuildPremium.guild_id == guild_db_id,
+        (GuildPremium.expires_at.is_(None)) | (GuildPremium.expires_at > datetime.utcnow())
     ))).scalar_one_or_none()
     return pm is not None

--- a/panel/routers/admin.py
+++ b/panel/routers/admin.py
@@ -3,9 +3,9 @@ from fastapi import APIRouter, Request, Form, HTTPException, Depends
 from fastapi.responses import HTMLResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
 from sqlalchemy.orm import Session
-from sqlalchemy import select, and_
+from sqlalchemy import select
 from core.db import get_db
-from core.models import User, Guild, PremiumMembership
+from core.models import User, Guild, GuildPremium
 from panel.deps import require_site_admin
 from datetime import datetime
 
@@ -16,30 +16,28 @@ router = APIRouter(prefix="/admin", tags=["admin"])
 def premium_index(request: Request, db: Session = Depends(get_db)):
     me = require_site_admin(request, db)
 
-    users = db.execute(select(User).order_by(User.id.desc()).limit(50)).scalars().all()
     guilds = db.execute(select(Guild).order_by(Guild.name)).scalars().all()
 
     rows = db.execute(
-        select(PremiumMembership, Guild, User)
-        .join(Guild, PremiumMembership.guild_id == Guild.id)
-        .join(User, PremiumMembership.user_id == User.id)
+        select(GuildPremium, Guild, User)
+        .join(Guild, GuildPremium.guild_id == Guild.id)
+        .outerjoin(User, GuildPremium.granted_by == User.id)
         .where(
-            (PremiumMembership.expires_at.is_(None)) |
-            (PremiumMembership.expires_at > datetime.utcnow())
+            (GuildPremium.expires_at.is_(None)) |
+            (GuildPremium.expires_at > datetime.utcnow())
         )
-        .order_by(Guild.name, User.display_name, User.username)
+        .order_by(Guild.name)
     ).all()
 
     premiums = []
-    for pm, g, u in rows:
+    for gp, g, u in rows:
         premiums.append({
             "guild_db_id": g.id,
             "guild_discord_id": g.discord_id,
             "guild_name": g.name,
-            "user_id": u.id,
-            "user_name": u.display_name or u.username,
-            "tier": pm.tier,
-            "expires_at": pm.expires_at,
+            "tier": gp.tier,
+            "expires_at": gp.expires_at,
+            "granted_by": (u.display_name or u.username) if u else None,
         })
 
     return templates.TemplateResponse(
@@ -47,41 +45,44 @@ def premium_index(request: Request, db: Session = Depends(get_db)):
         {
             "request": request,
             "user": request.session.get("user"),
-            "users": users,
             "guilds": guilds,
             "premiums": premiums,   # 👈 AJOUT
         },
     )
 
 @router.post("/premium/grant")
-def premium_grant(request: Request, user_id: int = Form(...), guild_id: int = Form(...),
+def premium_grant(request: Request, guild_id: int = Form(...),
                   tier: str = Form("premium"), expires_at: str | None = Form(None),
                   db: Session = Depends(get_db)):
     me = require_site_admin(request, db)
     from datetime import datetime
     g = db.get(Guild, guild_id)
-    u = db.get(User, user_id)
-    if not u or not g:
-        raise HTTPException(404, "User or guild not found")
-    pm = db.execute(select(PremiumMembership).where(
-        PremiumMembership.user_id==user_id, PremiumMembership.guild_id==guild_id
+    if not g:
+        raise HTTPException(404, "Guild not found")
+    gp = db.execute(select(GuildPremium).where(
+        GuildPremium.guild_id == guild_id
     )).scalar_one_or_none()
-    if not pm:
-        pm = PremiumMembership(user_id=user_id, guild_id=guild_id, tier=tier)
-        db.add(pm)
-    pm.tier = tier
+    if not gp:
+        gp = GuildPremium(guild_id=guild_id, tier=tier, granted_by=me.id)
+        db.add(gp)
+    else:
+        gp.tier = tier
+        gp.granted_by = me.id
     if expires_at:
-        pm.expires_at = datetime.fromisoformat(expires_at)
+        gp.expires_at = datetime.fromisoformat(expires_at)
+    else:
+        gp.expires_at = None
     db.commit()
     return RedirectResponse(url="/admin/premium", status_code=303)
 
 @router.post("/premium/revoke")
-def premium_revoke(request: Request, user_id: int = Form(...), guild_id: int = Form(...),
+def premium_revoke(request: Request, guild_id: int = Form(...),
                    db: Session = Depends(get_db)):
     me = require_site_admin(request, db)
-    pm = db.execute(select(PremiumMembership).where(
-        PremiumMembership.user_id==user_id, PremiumMembership.guild_id==guild_id
+    gp = db.execute(select(GuildPremium).where(
+        GuildPremium.guild_id == guild_id
     )).scalar_one_or_none()
-    if pm:
-        db.delete(pm); db.commit()
+    if gp:
+        db.delete(gp)
+        db.commit()
     return RedirectResponse(url="/admin/premium", status_code=303)

--- a/panel/routers/features.py
+++ b/panel/routers/features.py
@@ -15,7 +15,7 @@ router = APIRouter()
 def features_page(guild_id: str, request: Request, db: Session = Depends(get_db)):
     user = require_auth_request(request)
     g = require_guild_admin(request, int(guild_id), db)
-    if not has_premium(int(user["id"]), g.id, db):
+    if not has_premium(g.id, db):
         raise HTTPException(403, "Premium required for this guild")
 
     features = db.execute(select(Feature).order_by(Feature.id)).scalars().all()
@@ -33,7 +33,7 @@ def toggle_feature(guild_id: str, request: Request,
                    db: Session = Depends(get_db)):
     user = require_auth_request(request)
     g = require_guild_admin(request, int(guild_id), db)
-    if not has_premium(int(user["id"]), g.id, db):
+    if not has_premium(g.id, db):
         raise HTTPException(403, "Premium required")
 
     flag = db.execute(select(GuildFeatureFlag).where(and_(

--- a/panel/templates/admin_premium.html
+++ b/panel/templates/admin_premium.html
@@ -2,13 +2,6 @@
 {% block content %}
   <h2>Premium — Attribution</h2>
   <form method="post" action="/admin/premium/grant" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
-    <label>Utilisateur
-      <select name="user_id">
-        {% for u in users %}
-          <option value="{{u.id}}">{{ u.display_name or u.username }} ({{u.id}})</option>
-        {% endfor %}
-      </select>
-    </label>
     <label>Guilde
       <select name="guild_id">
         {% for g in guilds %}
@@ -32,7 +25,6 @@
         <tr>
             <th style="text-align:left;border-bottom:1px solid #333;padding:.4rem">Guilde</th>
             <th style="text-align:left;border-bottom:1px solid #333;padding:.4rem">Discord ID</th>
-            <th style="text-align:left;border-bottom:1px solid #333;padding:.4rem">Utilisateur</th>
             <th style="text-align:left;border-bottom:1px solid #333;padding:.4rem">Tier</th>
             <th style="text-align:left;border-bottom:1px solid #333;padding:.4rem">Expire</th>
         </tr>
@@ -42,7 +34,6 @@
             <tr>
             <td style="padding:.4rem">{{ row.guild_name or row.guild_discord_id }}</td>
             <td style="padding:.4rem">{{ row.guild_discord_id }}</td>
-            <td style="padding:.4rem">{{ row.user_name }} ({{ row.user_id }})</td>
             <td style="padding:.4rem">{{ row.tier }}</td>
             <td style="padding:.4rem">{{ row.expires_at or "—" }}</td>
             </tr>
@@ -55,7 +46,6 @@
 
   <h3 style="margin-top:1rem">Révoquer</h3>
   <form method="post" action="/admin/premium/revoke" style="display:flex;gap:8px;align-items:flex-end;flex-wrap:wrap">
-    <label>User ID <input name="user_id" required></label>
     <label>Guild ID (DB) <input name="guild_id" required></label>
     <button class="btn">Revoke</button>
   </form>


### PR DESCRIPTION
## Summary
- replace PremiumMembership with GuildPremium (guild_id unique, tier, expiry, granted_by)
- add migration dropping premium_memberships and creating guild_premium
- simplify has_premium and update feature toggling and admin premium management to be guild-only

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab71c2a3b483259f39da44ebdfb9ad